### PR TITLE
Incorrect building instructions on README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ Or you can download the source and build it manually:
 
     $ git clone https://febuiles@github.com/febuiles/s3share.git
     $ cd s3share
-    $ gem build
+    $ gem build s3share.gemspec
     $ gem install s3share --local
 
 


### PR DESCRIPTION
Running `gem build` gives:

```
$ gem build 
ERROR:  While executing gem ... (Gem::CommandLineError)
    Please specify a gem name on the command line (e.g. gem build GEMNAME)
```
