### PR TITLE
The URL that is copied to the clipboard should have special characters like # or ? escaped.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ Or you can download the source and build it manually:
 
     $ git clone https://febuiles@github.com/febuiles/s3share.git
     $ cd s3share
-    $ gem build
+    $ gem build s3share.gemspec
     $ gem install s3share --local
 
 

--- a/lib/s3share/runner.rb
+++ b/lib/s3share/runner.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module S3Share
   class Runner
     def initialize(*args)
@@ -71,7 +73,7 @@ module S3Share
                               :access => :public_read)
       t.kill
 
-      url = "http://s3.amazonaws.com/#{bucket_name}/#{@filename}"
+      url = "http://s3.amazonaws.com/#{bucket_name}/#{URI::escape(@filename)}"
       puts "\n #{@filename} uploaded to: #{url}\n\n"
       url
     end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'spec_helper'
 
 describe S3Share::Runner do
@@ -6,10 +7,11 @@ describe S3Share::Runner do
     S3Share::Runner.new(filename)
   end
 
-  let(:relative)      { runner("something/spec.opts") }
-  let(:absolute)      { runner("/Users/someone/something/spec.opts") }
-  let(:file)          { runner("spec.opts") }
-  let(:existing_file) { runner(__FILE__) }
+  let(:relative)             { runner("something/spec.opts") }
+  let(:absolute)             { runner("/Users/someone/something/spec.opts") }
+  let(:file)                 { runner("spec.opts") }
+  let(:existing_file)        { runner(__FILE__) }
+  let(:file_with_weird_name) { runner("¿Ñame con azúcar #1?.txt") }
 
   describe "#get_directory" do
     it "correctly expands a relative path" do
@@ -40,10 +42,19 @@ describe S3Share::Runner do
   end
   
   describe "#upload_file" do
-    it "checks if the bucket exists before starting the upload" do
+    before(:each) do
       # Stub this method so we don't try a real upload.
-      AWS::S3::S3Object.stub!(:store).and_return(nil) 
-      
+      AWS::S3::S3Object.stub!(:store).and_return(nil)
+    end
+    
+    it "copies an escaped URL to the clipboard after the upload has finished" do
+      file_with_weird_name.should_receive(:set_clipboard_url).with("http://s3.amazonaws.com/#{ENV["AMAZON_S3_DEFAULT_BUCKET"]}/%C2%BF%C3%91ame%20con%20az%C3%BAcar%20%231?.txt").and_return(0)
+      file_with_weird_name.stub!(:open).and_return(nil) # So it doesn't really try to read the file.
+      file_with_weird_name.stub!(:exit).and_return(nil) # Otherwise, the call to exit will make the test fail. I'm not sure why.
+      silence_stream(STDOUT) { file_with_weird_name.run }
+    end
+    
+    it "checks if the bucket exists before starting the upload" do
       ENV["AMAZON_S3_DEFAULT_BUCKET"] = "an_imaginary_bucket"
       existing_file.should_receive(:create_bucket_if_it_does_not_exist).with("an_imaginary_bucket").and_return(:nil)
       silence_stream(STDOUT) { existing_file.upload_file }


### PR DESCRIPTION
I tried uploading a file that had a space in the URL and my mom couldn't figure out how to open it when I pasted it on the Gtalk conversation. That totally spoiled the fun of using s3share :(

URLs should have spaces replaced with %20, #'s replaced with %23 and all that kind of stuff.
